### PR TITLE
Removed dbg! calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,6 @@ where
                     while let Some(i) = s.find(first_char) {
                         self.writer.write_str(&s[..i])?;
                         s = &s[i..];
-                        dbg!(s);
 
                         let mut len = first_char.len_utf8();
                         let needle_bytes = self.needle.as_bytes();
@@ -134,7 +133,6 @@ where
                         }
                     }
 
-                    dbg!(s);
                     self.writer.write_str(s)?;
                 }
             }


### PR DESCRIPTION
Hi,

first of all, thanks for making this! It came in handy for custom `Display` escapes.

However, there were a few `dbg!` calls left over in the change to 0.1.3.
This pull request removes them but doesn't bump the version (yet; Tell me if I should take care of it).

Cheers,
Tamschi